### PR TITLE
update: docker golang:1.16 -> golang:1.22

### DIFF
--- a/Deployments/Dockerfile
+++ b/Deployments/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16 as builder
+FROM golang:1.22 as builder
 # Setting environment variables
 ENV GOPROXY="https://goproxy.cn,direct" \
     GO111MODULE="on" \


### PR DESCRIPTION
docker打包失败，将[Deployments/Dockerfile](https://github.com/jxhczhl/JsRpc/blob/main/Deployments/Dockerfile) 中的`golang:1.16`更新为`golang:1.22`就可以正常打包了。

---

- 更新前：
<img width="933" height="735" alt="image" src="https://github.com/user-attachments/assets/36edf9f0-b715-4d9e-923b-7ef2a7cb0ee7" />

---

- 更新后：
<img width="920" height="754" alt="image" src="https://github.com/user-attachments/assets/4f0b9eb9-d986-4b87-a713-6738173be371" />
